### PR TITLE
fix: fixed module to be installable

### DIFF
--- a/project.janet
+++ b/project.janet
@@ -10,11 +10,11 @@
 
 (declare-executable
   :name "remark"
-  :entry "src/remarkable.janet")
+  :entry "src/remarkable/init.janet")
 
 
 (declare-source
-  :source ["src/remarkable.janet"])
+  :source ["src/remarkable"])
 
 
 (phony "spec" []

--- a/src/remarkable/init.janet
+++ b/src/remarkable/init.janet
@@ -1,10 +1,10 @@
-(use ./remarkable/globals)
+(use ./globals)
 
 
-(import ./remarkable/blocks)
-(import ./remarkable/inlines)
-(import ./remarkable/parser)
-(import ./remarkable/renderers/html)
+(import ./blocks)
+(import ./inlines)
+(import ./parser)
+(import ./renderers/html)
 
 
 (defn parse-md [input &opt your-blocks your-inlines your-functions your-priorities]


### PR DESCRIPTION
Remarkable can now be used as a library with these fixes thanks to bakpakin